### PR TITLE
Missing property that causes rendering a label's i11n variable instead of actual translation

### DIFF
--- a/translations/de.json
+++ b/translations/de.json
@@ -80,6 +80,7 @@
       "delete": "Zutat löschen und überall entfernen",
       "name": "Name",
       "unit": "Einheit",
+      "category": "Kategorie",
       "save": "Zutat speichern"
     }
   },

--- a/translations/en.json
+++ b/translations/en.json
@@ -80,6 +80,7 @@
       "delete": "Delete ingredient and remove everywhere",
       "name": "Name",
       "unit": "Unit",
+      "category": "Category",
       "save": "Save ingredient"
     }
   },


### PR DESCRIPTION
Just found out about this and wanted to help out.

I don't know if you want to have another "flow" to merge PRs, if that's the case, I'm willing to change the PR :)!
Great work on your development.

URL of the issue: https://yummyplan.github.io/ingredients

It occurs in both possible languages:
![image](https://user-images.githubusercontent.com/1178493/110252422-9f9a4e80-7f85-11eb-8122-074cca13a286.png)
![image](https://user-images.githubusercontent.com/1178493/110252427-a6c15c80-7f85-11eb-985f-900671e06148.png)
